### PR TITLE
Add test to check that we can close a running pour

### DIFF
--- a/chan_test.go
+++ b/chan_test.go
@@ -1,0 +1,63 @@
+package luigi
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// verify we can abort a pipe while it is waiting to read/write it's data
+
+func TestCloseWhileNext(t *testing.T) {
+	ctx := context.TODO()
+	r := require.New(t)
+
+	errc := make(chan error)
+
+	src, sink := NewPipe()
+
+	go func() {
+		errc <- sink.Close()
+	}()
+
+	v, err := src.Next(ctx)
+	r.Equal(EOS{}, err, "should return end of stream")
+	r.Nil(v)
+
+	r.NoError(<-errc)
+}
+
+func TestCloseWhilePour(t *testing.T) {
+	ctx := context.TODO()
+	r := require.New(t)
+
+	closeErr := make(chan error)
+	nextErr := make(chan error)
+
+	src, sink := NewPipe()
+
+	go func() {
+		time.Sleep(25 * time.Millisecond) // just make sure Pour() started
+		closeErr <- sink.Close()
+		go func() {
+			v, err := src.Next(ctx)
+			if v != nil {
+				nextErr <- errors.Errorf("expected nil value but got %v", v)
+			}
+			nextErr <- errors.Wrap(err, "error from next")
+			close(nextErr)
+		}()
+	}()
+
+	err := sink.Pour(ctx, "test msg")
+	r.Equal(EOS{}, err, "should return end of stream")
+
+	r.NoError(<-closeErr)
+
+	for err := range nextErr {
+		r.NoError(err)
+	}
+}

--- a/chan_test.go
+++ b/chan_test.go
@@ -47,13 +47,16 @@ func TestCloseWhilePour(t *testing.T) {
 			if v != nil {
 				nextErr <- errors.Errorf("expected nil value but got %v", v)
 			}
-			nextErr <- errors.Wrap(err, "error from next")
+			if !IsEOS(err) {
+				nextErr <- errors.Wrap(err, "error from next")
+			}
 			close(nextErr)
 		}()
 	}()
 
 	err := sink.Pour(ctx, "test msg")
-	r.Equal(EOS{}, err, "should return end of stream")
+	// TODO use exported error variables
+	r.EqualError(err, "pour to closed sink", "should return end of stream")
 
 	r.NoError(<-closeErr)
 

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestBufferedPipe(t *testing.T) {
-	r := require.New(t)
 
 	mkTest := func(bufSize int) func(*testing.T) {
 		return func(t *testing.T) {
+			r := require.New(t)
 			src, sink := NewPipe(WithBuffer(bufSize))
 
 			ctx := context.Background()


### PR DESCRIPTION
currently blocks infinitely since it's contesting for the same lock:

```
goroutine 53 [select]:
go.cryptoscope.co/luigi.(*chanSink).Pour(0xc00010a120, 0x1348180, 0xc000014070, 0x12909e0, 0x1343800, 0x0, 0x0)
	/Users/cryptix/go-verse/src/go.cryptoscope.co/luigi/chan.go:138 +0x23d
go.cryptoscope.co/luigi.TestCloseWhilePour(0xc000130100)
	/Users/cryptix/go-verse/src/go.cryptoscope.co/luigi/chan_test.go:55 +0x176
testing.tRunner(0xc000130100, 0x130f718)
	/usr/local/Cellar/go/1.11.4/libexec/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
	/usr/local/Cellar/go/1.11.4/libexec/src/testing/testing.go:878 +0x35c

goroutine 54 [semacquire]:
sync.runtime_SemacquireMutex(0xc000100184, 0x100d400)
	/usr/local/Cellar/go/1.11.4/libexec/src/runtime/sema.go:71 +0x3d
sync.(*Mutex).Lock(0xc000100180)
	/usr/local/Cellar/go/1.11.4/libexec/src/sync/mutex.go:134 +0xff
go.cryptoscope.co/luigi.(*chanSink).CloseWithError.func1()
	/Users/cryptix/go-verse/src/go.cryptoscope.co/luigi/chan.go:155 +0x49
sync.(*Once).Do(0xc00010a140, 0xc00002bee0)
	/usr/local/Cellar/go/1.11.4/libexec/src/sync/once.go:44 +0xb3
go.cryptoscope.co/luigi.(*chanSink).CloseWithError(0xc00010a120, 0x1345b20, 0x1540e88, 0x15276c0, 0x15276c0)
	/Users/cryptix/go-verse/src/go.cryptoscope.co/luigi/chan.go:154 +0x6d
go.cryptoscope.co/luigi.(*chanSink).Close(0xc00010a120, 0x0, 0x0)
	/Users/cryptix/go-verse/src/go.cryptoscope.co/luigi/chan.go:150 +0x43
go.cryptoscope.co/luigi.TestCloseWhilePour.func1(0xc00012e240, 0x1346d40, 0xc00010a120, 0x1345260, 0xc0000fe280, 0x1348180, 0xc000014070, 0xc00012e2a0)
	/Users/cryptix/go-verse/src/go.cryptoscope.co/luigi/chan_test.go:44 +0x42
created by go.cryptoscope.co/luigi.TestCloseWhilePour
	/Users/cryptix/go-verse/src/go.cryptoscope.co/luigi/chan_test.go:42 +0x134
```

I'm thinking it's to simple to share (and close) the value channel and a 2nd _closing_ channel might be better so that we don't _send on closed_ and can just select the _closing_ channel on both ends of the pipe. @keks what do you think?